### PR TITLE
Add buttonmap.xml and topology.xml

### DIFF
--- a/game.libretro.mu/addon.xml.in
+++ b/game.libretro.mu/addon.xml.in
@@ -5,6 +5,7 @@
 		provider-name="guicrith / meepingsnesroms; Stephanie Gawroriski (Xer Shadow Tail)">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
+		<import addon="game.controller.default" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.mu/resources/buttonmap.xml
+++ b/game.libretro.mu/resources/buttonmap.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<buttonmap version="2">
+  <controller id="game.controller.default" type="RETRO_DEVICE_ANALOG">
+    <!-- Touchscreen Mouse X/Y -->
+    <feature name="leftstick" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT"/>
+    <!-- Touchscreen Mouse Click -->
+    <feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+    <!-- Dpad Up -->
+    <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+    <!-- Dpad Down -->
+    <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+    <!-- Dpad Left -->
+    <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+    <!-- Dpad Right -->
+    <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+    <!-- Dpad Center -->
+    <feature name="back" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+    <!-- Power -->
+    <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
+    <!-- Date Book -->
+    <feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
+    <!-- Address Book -->
+    <feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
+    <!-- To Do List -->
+    <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+    <!-- Note Pad -->
+    <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+  </controller>
+</buttonmap>

--- a/game.libretro.mu/resources/topology.xml
+++ b/game.libretro.mu/resources/topology.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logicaltopology>
+  <port type="controller" id="1">
+    <accepts controller="game.controller.default"/>
+  </port>
+</logicaltopology>


### PR DESCRIPTION
## Description

This PR adds buttonmap.xml and topology.xml.

Data comes from source: https://github.com/libretro/Mu/blob/master/libretroBuildSystem/libretro.c

## How has this been tested?

Loaded mu, after pasting BIOS into system directory:

```
debug <general>: AddOnLog: game.libretro.mu: Libretro input bindings:
debug <general>: AddOnLog: game.libretro.mu: ------------------------------------------------------------
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_ANALOG, Feature: RETRO_DEVICE_INDEX_ANALOG_LEFT, Component: RETRO_DEVICE_ID_ANALOG_X, Description: Touchscreen Mouse X
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_ANALOG, Feature: RETRO_DEVICE_INDEX_ANALOG_LEFT, Component: RETRO_DEVICE_ID_ANALOG_Y, Description: Touchscreen Mouse Y
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_R, Description: Touchscreen Mouse Click
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_UP, Description: Dpad Up
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_DOWN, Description: Dpad Down
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_LEFT, Description: Dpad Left
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_RIGHT, Description: Dpad Right
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_SELECT, Description: Dpad Center
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_START, Description: Power
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_Y, Description: Date Book
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_X, Description: Address Book
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_B, Description: To Do List
debug <general>: AddOnLog: game.libretro.mu: Port: 0, Device: RETRO_DEVICE_JOYPAD, Feature: RETRO_DEVICE_ID_JOYPAD_A, Description: Note Pad
debug <general>: AddOnLog: game.libretro.mu: ------------------------------------------------------------
```